### PR TITLE
Force utf-8 encoding on deserialized strings

### DIFF
--- a/lib/borsh/readable.rb
+++ b/lib/borsh/readable.rb
@@ -105,7 +105,7 @@ module Borsh::Readable
   end
 
   def read_string
-    self.read(self.read_u32)
+    self.read(self.read_u32).force_encoding('UTF-8')
   end
 
   def read_array(element_type, count)

--- a/spec/read_string.rb
+++ b/spec/read_string.rb
@@ -1,0 +1,13 @@
+require 'borsh'
+
+RSpec.describe Borsh do
+  it 'roundtrip string with unicode chars' do
+    serialized_data = Borsh::Buffer.open do |buf|
+      buf.write_string("🙂")
+    end
+
+    Borsh::Buffer.new(serialized_data) do |buf|
+      expect(buf.read_string).to eq("🙂")
+    end
+  end
+end


### PR DESCRIPTION
### Background
Borsh.rb doesn't roundtrip correctly when decoded string includes unicode chars.

I noticed that when JSON gem produced a warning
> JSON.generate: UTF-8 string passed as BINARY, this will raise an encoding error in json 3.0

### Additional info
According to the [spec](https://github.com/near/borsh?tab=readme-ov-file#specification), strings must be utf-8 encoded.
